### PR TITLE
Adding multi-line input support

### DIFF
--- a/src/dymaptic.Chat.ArcGIS/DymapticChatDockpaneView.xaml
+++ b/src/dymaptic.Chat.ArcGIS/DymapticChatDockpaneView.xaml
@@ -98,17 +98,29 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBox FontSize="13" Grid.ColumnSpan="3" Padding="10 15 30 15" Style="{DynamicResource SearchTextBoxStyle}" BorderThickness="0" Foreground="{DynamicResource TextColor}" Text="{Binding MessageText, UpdateSourceTrigger=PropertyChanged}" ToolTip="Send query">
+            <TextBox FontSize="13" Grid.ColumnSpan="3" Padding="10 15 30 15" Style="{DynamicResource SearchTextBoxStyle}" BorderThickness="0" 
+                     Foreground="{DynamicResource TextColor}" 
+                     Text="{Binding MessageText, UpdateSourceTrigger=PropertyChanged}" 
+                     ToolTip="Send query"
+                     TextWrapping="Wrap"
+                     AcceptsReturn="True"
+                     AcceptsTab="True"
+                     HorizontalScrollBarVisibility="Disabled"
+                     VerticalScrollBarVisibility="Hidden" MaxHeight="100" VerticalAlignment="Center"
+                     MinHeight="35">
                 <adorners:WatermarkService.Watermark>
                     <TextBlock FontSize="13" Foreground="{DynamicResource TextColor}">Type message here...</TextBlock>
                 </adorners:WatermarkService.Watermark>
+                <TextBox.InputBindings>
+                    <KeyBinding Key="ENTER" Command="{Binding SendMessageCommand}"/>
+                </TextBox.InputBindings>
             </TextBox>
-            <Button Grid.Column="1" Style="{DynamicResource SimpleIconButtonStyle}" HorizontalAlignment="Right"  Margin="0 0 0 0 " FontWeight="Bold" FontSize="16" Padding="-2 -2 0 -2" IsDefault="True" Command="{Binding SendMessageCommand}">
+            <Button Grid.Column="1" Style="{DynamicResource SimpleIconButtonStyle}" HorizontalAlignment="Right" VerticalAlignment="Bottom"  Margin="0 10 0 10" FontWeight="Bold" FontSize="16" Padding="-2 -2 0 -2" IsDefault="True" Command="{Binding SendMessageCommand}">
                 <Border Padding="5">
                     <Rectangle Width="20" Height="20" Fill="{DynamicResource SendIconBrush}"/>
                 </Border>
             </Button>
-            <Button Grid.Column="2" Style="{DynamicResource SimpleIconButtonStyle}" HorizontalAlignment="Right"  Margin="5 0 0 0 " FontWeight="Bold" ToolTip="Clear Window" Command="{Binding ClearMessagesCommand}" >
+            <Button Grid.Column="2" Style="{DynamicResource SimpleIconButtonStyle}" HorizontalAlignment="Right" VerticalAlignment="Bottom"  Margin="5 0 0 6" FontWeight="Bold" ToolTip="Clear Window" Command="{Binding ClearMessagesCommand}" >
                 <Border Padding="5">
                     <Rectangle Width="20" Height="20" Fill="{DynamicResource ClearIconBrush}" />
                 </Border>

--- a/src/dymaptic.Chat.ArcGIS/DymapticChatDockpaneViewModel.cs
+++ b/src/dymaptic.Chat.ArcGIS/DymapticChatDockpaneViewModel.cs
@@ -450,7 +450,7 @@ internal class DymapticChatDockpaneViewModel : DockPane
 
     private StringBuilder _responseMessageBuilder = new();
     private ArcGISMessage _welcomeMessage => new ArcGISMessage(
-        "Hello! My name is Jackson Carter, I am here to help! \r\n Start typing a question and let's make some awesome maps. \r\n I am powered by AI, so please verify any suggestions I make.",
+        "Hello! My name is Jackson Carter, I am here to help! Start typing a question and let's make some awesome maps. I am powered by AI, so please verify any suggestions I make.",
         DyChatSenderType.Bot, "dymaptic")
     {
         LocalTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),

--- a/src/dymaptic.Chat.ArcGIS/Markdown/MarkdownViewer.cs
+++ b/src/dymaptic.Chat.ArcGIS/Markdown/MarkdownViewer.cs
@@ -1,4 +1,7 @@
-﻿namespace dymaptic.Chat.ArcGIS.Markdown;
+﻿using System;
+using Markdig;
+
+namespace dymaptic.Chat.ArcGIS.Markdown;
 
 /// <summary>
 /// Usually the image paths in the Markdown must be relative to the application or absolute.
@@ -6,10 +9,35 @@
 /// </summary>
 public class MarkdownViewer : Markdig.Wpf.MarkdownViewer
 {
+    protected new static readonly MarkdownPipeline DefaultPipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
 
     protected override void RefreshDocument()
     {
         Document = Markdown != null ? Markdig.Wpf.Markdown.ToFlowDocument(Markdown, Pipeline ?? DefaultPipeline, new WpfRenderer()) : null;
+    }
+}
+
+
+/// <summary>
+/// This overrides the default Markdig renderer to add support for UseSoftlineBreakAsHardlineBreak which is used when setting up the default pipeline
+/// </summary>
+public static class MarkdownExtensions
+{
+    /// <summary>
+    /// Uses all extensions supported by <c>Markdig.Wpf</c>.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    /// <returns>The modified pipeline</returns>
+    public static MarkdownPipelineBuilder UseSupportedExtensions(this MarkdownPipelineBuilder pipeline)
+    {
+        if (pipeline == null) throw new ArgumentNullException(nameof(pipeline));
+        return pipeline
+            .UseEmphasisExtras()
+            .UseGridTables()
+            .UsePipeTables()
+            .UseTaskLists()
+            .UseAutoLinks()
+            .UseSoftlineBreakAsHardlineBreak();
     }
 }
 


### PR DESCRIPTION
closes #29 
Adding the ability to paste multi-line input and have it display correctly.
Also now displaying multi-line output from the chat bot
Enter still submits the entry
Chat entry expands to ~ 4 lines of input before scrolling.